### PR TITLE
feat: 회원 검색, 회의록 조회, 회의록 단건 조회, PDF 다운로드 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "bootstrap": "^5.3.3",
         "bootstrap-icons": "^1.11.3",
         "file-saver": "^2.0.5",
+        "marked": "^14.1.2",
         "react": "^18.3.1",
         "react-bootstrap": "^2.10.4",
         "react-dom": "^18.3.1",
@@ -12156,6 +12157,17 @@
       "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.2.tgz",
+      "integrity": "sha512-f3r0yqpz31VXiDB/wj9GaOB0a2PRLQl6vJmXiFrniNwjkKdvakqJRULhjFKJpxOchlCRiG5fcacoUZY5Xa6PEQ==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mdn-data": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bootstrap": "^5.3.3",
     "bootstrap-icons": "^1.11.3",
     "file-saver": "^2.0.5",
+    "marked": "^14.1.2",
     "react": "^18.3.1",
     "react-bootstrap": "^2.10.4",
     "react-dom": "^18.3.1",

--- a/src/pages/RecordPage.js
+++ b/src/pages/RecordPage.js
@@ -3,54 +3,32 @@ import React, { useState } from 'react';
 import { Container, Card, Form, Button } from 'react-bootstrap';
 import 'bootstrap-icons/font/bootstrap-icons.css';
 import './RecordPage.css';
-
+import { client } from '../utils/client';
 
 const RecordPage = () => {
-  // 회원 데이터 (예시 데이터)
-  const members = [
-    '김철수',
-    '박영희',
-    '이민호',
-    '홍길동',
-    '강수진',
-    '최준호',
-    '김지수',
-    '이수민',
-    '한가영',
-    '윤종훈',
-    'qwerqwer',
-    'qwerqwer1'
-  ];
-
-  
   // 상태 관리
   const [searchTerm, setSearchTerm] = useState('');
   const [filteredMembers, setFilteredMembers] = useState([]);
-  const [selectedMembers, setSelectedMembers] = useState([]); // 클릭된 회원들을 배열로 저장
+  const [selectedMemberUsernames, setSelectedMemberUsernames] = useState([]); // 클릭된 회원들을 배열로 저장
   const [isRecording, setIsRecording] = useState(false); // 녹음 상태 관리
 
   // 검색어 입력 처리 함수
   const handleSearchChange = (event) => {
     const value = event.target.value;
+    searchMember(value);
     setSearchTerm(value);
-
-    // 필터링된 회원 목록 업데이트
-    const filtered = value
-      ? members.filter((member) => member.includes(value)) // 검색어가 있으면 필터링
-      : []; // 검색어가 없으면 빈 배열
-    setFilteredMembers(filtered);
   };
 
   // 회원 카드 클릭 처리 함수 (플러스 아이콘과 통합)
   const handleMemberClick = (member) => {
-    if (member && !selectedMembers.includes(member)) {
-      setSelectedMembers((prevSelected) => [...prevSelected, member]); // 이전 상태를 기반으로 업데이트
+    if (member && !selectedMemberUsernames.includes(member)) {
+      setSelectedMemberUsernames((prevSelected) => [...prevSelected, member.username]); // 이전 상태를 기반으로 업데이트
     }
   };
 
   // 회원 카드 삭제 처리 함수
   const handleRemoveMember = (member) => {
-    setSelectedMembers((prevSelected) => prevSelected.filter((m) => m !== member)); // 선택된 회원 제거
+    setSelectedMemberUsernames((prevSelected) => prevSelected.filter((m) => m !== member)); // 선택된 회원 제거
   };
 
   // 음성 녹음 저장 처리 함수
@@ -70,6 +48,15 @@ const RecordPage = () => {
       alert('녹음을 중지합니다.');
     }
   };
+
+  const searchMember = async(query) => {
+    const res = await client.get(`/member/search?query=${query}`, {
+      headers: {
+        Authorization: process.env.REACT_APP_TEMP_AUTH_HEADER // 로그인 구현되면 수정 필요
+      }
+    });
+    setFilteredMembers(res);
+  }
 
 
   return (
@@ -124,10 +111,10 @@ const RecordPage = () => {
                   >
                     <Card.Body style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                       <Card.Text className="fw-bold" style={{ margin: 0, flex: '1', textAlign: 'center' }}>
-                        {member}
+                        {member.username}
                       </Card.Text>
                       {/* 추가된 회원이 아닌 경우에만 플러스 아이콘 표시 */}
-                      {!selectedMembers.includes(member) && (
+                      {!selectedMemberUsernames.includes(member.username) && (
                         <i className="bi bi-plus-circle" 
                           onClick={(e) => {
                             e.stopPropagation(); // 부모 요소의 클릭 이벤트 중지
@@ -174,9 +161,9 @@ const RecordPage = () => {
           justifyContent: 'flex-start', // 카드들을 왼쪽 정렬
           padding: '0 10px', // 좌우 패딩 추가
       }}>
-        {selectedMembers.length > 0 && (
+        {selectedMemberUsernames.length > 0 && (
           <>
-            {selectedMembers.map((member, index) => (
+            {selectedMemberUsernames.map((username, index) => (
               <div key={index} style={{ 
                   margin: '10px 0 5px',
                   marginLeft: '5px',
@@ -195,7 +182,7 @@ const RecordPage = () => {
                       variant="link" // 링크 스타일로 설정
                       onClick={(e) => {
                         e.stopPropagation(); // 클릭 이벤트 전파 방지
-                        handleRemoveMember(member);
+                        handleRemoveMember(username);
                       }}
                       style={{
                         position: 'absolute',
@@ -220,7 +207,7 @@ const RecordPage = () => {
                         whiteSpace: 'nowrap', // 텍스트를 한 줄로 제한
                       }}
                     >
-                      {member}
+                      {username}
                     </Card.Text>
                   </Card.Body>
                 </Card>

--- a/src/pages/SmPage.js
+++ b/src/pages/SmPage.js
@@ -1,7 +1,6 @@
 import '../background.scss';
 import './SmPage.css';
 import React, { useEffect, useState } from 'react';
-import { saveAs } from 'file-saver';
 import { FaFilePdf } from "react-icons/fa6";
 import { client } from '../utils/client';
 import { marked } from 'marked';
@@ -11,12 +10,12 @@ export default function SmPage() {
     const [meetingMinutes, setMeetingMinutes] = useState([]);
 
     // PDF 파일 다운로드
-    const handleDownloadPDF = () => {
-      if (!selectedMeeting) return;
-
-      const blob = new Blob([selectedMeeting.content], { type: 'application/pdf' });
-      saveAs(blob, `${selectedMeeting.title}.pdf`);
-  };
+    const handleDownloadPDF = async(reportId) => {
+        const res = await client.post(`/report/pdf`, {reportId}, {
+            headers: {Authorization: process.env.REACT_APP_TEMP_AUTH_HEADER} // 로그인 구현되면 수정 필요
+        });
+        window.open(res.pdfDownloadUrl, "_blank");
+    };
 
   useEffect(() => {
     fetchDocs();
@@ -27,7 +26,6 @@ export default function SmPage() {
         headers: {Authorization: process.env.REACT_APP_TEMP_AUTH_HEADER} // 로그인 구현되면 수정 필요
     });
     setMeetingMinutes(res);
-    console.log(res);
   }
 
   const fetchDetail = async(reportId) => {
@@ -91,7 +89,7 @@ export default function SmPage() {
                          {/* 다운로드 PDF 버튼을 아이콘과 텍스트 링크로 변경 */}
                          <div className="download-btn">
                             <FaFilePdf />
-                            <a href="#" onClick={handleDownloadPDF} style={{
+                            <a href="#" onClick={() => handleDownloadPDF(selectedMeeting.id)} style={{
                                 fontSize: '1rem',
                                 color: '#007bff',
                                 textDecoration: 'underline',

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -1,0 +1,37 @@
+export async function client(endpoint, { body, ...customConfig } = {}) {
+  const SERVER_URL = process.env.REACT_APP_SERVER_API_URL;
+  const headers = { 'Content-Type': 'application/json' };
+
+  const config = {
+    method: body ? 'POST' : 'GET',
+    ...customConfig,
+    headers: {
+      ...headers,
+      ...customConfig.headers,
+    },
+  }
+
+  if (body) {
+    config.body = JSON.stringify(body);
+  }
+
+  let data;
+  try {
+    const response = await fetch(SERVER_URL+endpoint, config);
+    if (response.ok) {
+      data = await response.json();
+      return data;
+    }
+    throw new Error(response.statusText);
+  } catch (err) {
+    return Promise.reject(err.message ? err.message : data);
+  }
+}
+
+client.get = function (endpoint, customConfig = {}) {
+  return client(endpoint, { ...customConfig, method: 'GET' });
+}
+
+client.post = function (endpoint, body, customConfig = {}) {
+  return client(endpoint, { ...customConfig, body });
+}


### PR DESCRIPTION
**Description**
- 회원 검색, 회의록 조회, 회의록 단건 조회, PDF 다운로드 부분을 백엔드 API와 연결하였습니다.
- `.env` 파일을 만들고, 다음과 같은 내용을 추가하셔야 잘 동작 합니다.
  ```
  REACT_APP_SERVER_API_URL=http://localhost:8080/api
  REACT_APP_TEMP_AUTH_HEADER=Bearer eyJhbGciOi....
  ```
- REACT_APP_TEMP_AUTH_HEADER는 임시 토큰이며, 서버에서 발급받아 사용하시면 됩니다.
- 로그인이 구현되면 해당 환경변수를 제거하고 다른 방식으로 구현될 예정입니다.
- client util을 만들어 두었는데, 이걸 사용하면 더 간편하게 api 통신을 할 수 있습니다.
- 마크다운 형식의 문자열이 표현될 수 있도록 구현하였습니다. `npm i`를 통해 패키지를 업데이트 해야 합니다.
<img width="1488" alt="Screenshot 2024-09-26 at 19 08 51" src="https://github.com/user-attachments/assets/b1acc5b9-4c66-4edf-9a1f-ba6458e8eec3">
<img width="1482" alt="Screenshot 2024-09-26 at 19 08 57" src="https://github.com/user-attachments/assets/eb4ee1a3-e96d-4c0d-9846-716063d90379">